### PR TITLE
Arreglo en contact e idea fondo

### DIFF
--- a/public/Circle Contact.svg
+++ b/public/Circle Contact.svg
@@ -1,0 +1,9 @@
+<svg width="615" height="950" viewBox="0 0 615 950" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="-86.0001" cy="701" r="700" transform="rotate(105 -86.0001 701)" fill="url(#paint0_linear_200_2031)" fill-opacity="0.9"/>
+<defs>
+<linearGradient id="paint0_linear_200_2031" x1="305.562" y1="103.813" x2="-720.874" y2="1123.57" gradientUnits="userSpaceOnUse">
+<stop stop-color="#070009" stop-opacity="0"/>
+<stop offset="1" stop-color="#700796" stop-opacity="0.9"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -17,12 +17,12 @@ export default function Home() {
   const t = useTranslations('Index');
 
   return (
-    <main className="">
-      <Header 
+    <main className="relative">
+      <Header
         btnLegendTitleResponsive={t('header.btn_title_responsive')}
-        btnLegendServices={t('header.btn_services')} 
-        btnLegendClients={t('header.btn_clients')} 
-        btnLegendAboutUs={t('header.btn_about_us')} 
+        btnLegendServices={t('header.btn_services')}
+        btnLegendClients={t('header.btn_clients')}
+        btnLegendAboutUs={t('header.btn_about_us')}
         btnLegendSpanishText={t('header.btn_spanish_text')}
         btnLegendEnglishText={t('header.btn_english_text')}
         btnLegendContact={t('header.btn_contact')}
@@ -32,19 +32,25 @@ export default function Home() {
         <Intro
           title={t("intro.section_1.title")}
           description={t("intro.section_1.description")}
-        /> 
+        />
       </div>
-        <Video/>
-        <div className='px-8 md:px-0 md:mb-8 mt-2 flex flex-col gap-24 container mx-auto'>
+      <Video />
+      <div className='px-8 md:px-0 md:mb-8 mt-2 flex flex-col gap-24 container mx-auto'>
         <Services />
-        </div>
+      </div>
       {/*  <Processes/> */}
-        <Hexagon/>
-        <Enterprises/>
-        <CasosDeExitos/>
-        <Contact /> 
-      
+      <Hexagon />
+      <Enterprises />
+      <CasosDeExitos />
+      <Contact />
+
       <Footer />
+
+      <div
+        className="hidden md:block absolute bottom-32 left-0 transform -translate-y-4 w-[600px] h-[800px] bg-no-repeat bg-cover z-0"
+        style={{ backgroundImage: "url('Circle Contact.svg')" }}
+      ></div>
+
     </main>
   )
 }

--- a/src/components/Contact/index.tsx
+++ b/src/components/Contact/index.tsx
@@ -6,9 +6,8 @@ const Contact = () => {
   const t = useTranslations('Index')
 
   return (
-    <div id='contact' className='relative flex flex-col md:flex-row gap-4 p-6 pt-12 pb-20 md:p-18 md:pb-26'>
+    <div id='contact' className='relative flex flex-col md:flex-row gap-4 p-6 pt-12 pb-20 md:p-18 md:pb-26 md:pt-30 z-10'>
       <div className="w-full md:w-2/4 text-right md:text-right relative">
-        <Image src='/Group 37.svg' alt='decoration' width={100} height={100} className='absolute -z-10 hidden md:block w-[194px] aspect-square -left-30 -bottom-20' />
         <h2 className="md:pl-28 mb-2 text-3xl md:text-5xl font-semibold text-transparent bg-clip-text bg-text-gradient whitespace-pre-line">
           {t("intro.section_3.title")}
         </h2>

--- a/src/components/ContactForm/index.tsx
+++ b/src/components/ContactForm/index.tsx
@@ -92,7 +92,12 @@ const ContactForm = ({
               legendSuccess
             }
           </small>
-          <Button variant={ButtonVariation.outline} label={isSubmitted.isLoading ? btnLoading : btnToSend} className='contact-form-button w-full md:w-[initial] px-16 md:px-20 py-2 md:py-3 disabled:cursor-not-allowed' disabled={!values.subject && !values.email && !values.message} />
+          <Button 
+            variant={ButtonVariation.outline} 
+            label={isSubmitted.isLoading ? btnLoading : btnToSend} 
+            className='contact-form-button w-full md:w-[initial] px-16 md:px-20 py-2 md:py-3 disabled:cursor-not-allowed' 
+            disabled={!values.subject || !values.email || !values.message} 
+          />
         </div>
       </form>
     </>


### PR DESCRIPTION
-Puse el fondo para el Contacto Form por el momento y si me dan el Ok continúo por los círculos que faltan en el resto de la página.
Vas a ver que lo agregué como un div suelto en Page.tsx, porque viendo siguiendo el Figma hay componentes que comparten circulo de fondo entre si, y haciendo el fondo solo desde dentro de un componente se cortaba con el limite sus contenedor.

- Corregí una condición para que el boton de enviar solo se habilite si estan los tres inputs con datos (cambie && por ||).

Cualquier cosa chiflame si hay que hacerlo de otra forma.

Gracias!

